### PR TITLE
feat(address-book): implement AddressBook CRUD, search and upcoming b…

### DIFF
--- a/personal_assistant/models/address_book.py
+++ b/personal_assistant/models/address_book.py
@@ -1,9 +1,8 @@
 from collections import UserDict
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from personal_assistant.models.record import Record
 
-datetime = __import__("datetime").datetime
 
 
 class AddressBook(UserDict[str, Record]):

--- a/personal_assistant/models/address_book.py
+++ b/personal_assistant/models/address_book.py
@@ -1,22 +1,70 @@
 from collections import UserDict
+from datetime import date, timedelta
 
 from personal_assistant.models.record import Record
+
+datetime = __import__("datetime").datetime
 
 
 class AddressBook(UserDict[str, Record]):
     """Клас для зберігання та керування записами контактів."""
 
     def add_record(self, record: Record) -> None:
-        raise NotImplementedError
+        self.data[record.name.value] = record
 
     def find(self, name: str) -> Record | None:
-        raise NotImplementedError
+        return self.data.get(name)
 
     def delete(self, name: str) -> None:
-        raise NotImplementedError
+        self.data.pop(name, None)
 
     def search(self, query: str) -> list[Record]:
-        raise NotImplementedError
+        q = query.lower()
+        results: list[Record] = []
+        for record in self.data.values():
+            if (
+                q in record.name.value.lower()
+                or any(q in phone.value.lower() for phone in record.phones)
+                or (record.email and q in record.email.value.lower())
+            ):
+                results.append(record)
+        return results
 
     def get_upcoming_birthdays(self, days: int = 7) -> list[dict[str, str]]:
-        raise NotImplementedError
+        today = datetime.today().date()
+        upcoming: list[dict[str, str]] = []
+
+        for record in self.data.values():
+            if record.birthday is None:
+                continue
+
+            bday: date = record.birthday.value  # type: ignore[assignment]
+            # Feb 29 birthdays are always celebrated on March 1
+            if bday.month == 2 and bday.day == 29:
+                bday_this_year = date(today.year, 3, 1)
+            else:
+                bday_this_year = bday.replace(year=today.year)
+
+            if bday_this_year < today:
+                if bday.month == 2 and bday.day == 29:
+                    bday_this_year = date(today.year + 1, 3, 1)
+                else:
+                    bday_this_year = bday.replace(year=today.year + 1)
+
+            delta = (bday_this_year - today).days
+            if 0 <= delta <= days:
+                congratulation_date = bday_this_year
+                weekday = congratulation_date.weekday()
+                if weekday == 5:  # Saturday
+                    congratulation_date += timedelta(days=2)
+                elif weekday == 6:  # Sunday
+                    congratulation_date += timedelta(days=1)
+
+                upcoming.append(
+                    {
+                        "name": record.name.value,
+                        "congratulation_date": congratulation_date.strftime("%d.%m.%Y"),
+                    }
+                )
+
+        return upcoming

--- a/personal_assistant/models/address_book.py
+++ b/personal_assistant/models/address_book.py
@@ -4,7 +4,6 @@ from datetime import date, datetime, timedelta
 from personal_assistant.models.record import Record
 
 
-
 class AddressBook(UserDict[str, Record]):
     """Клас для зберігання та керування записами контактів."""
 


### PR DESCRIPTION
## Опис змін

Реалізовано клас `AddressBook(UserDict[str, Record])` — колекція контактів з повним CRUD, пошуком та логікою майбутніх днів народження.

Реалізовані методи:
- `add_record(record)` — зберігає запис за `record.name.value`, перезаписує якщо ім'я вже існує
- `find(name)` — повертає `Record | None`
- `delete(name)` — видаляє запис, не падає якщо не існує
- `search(query)` — часткове співпадіння (case-insensitive) по імені, телефонах та email
- `get_upcoming_birthdays(days=7)` — список `{"name": ..., "congratulation_date": ...}` з урахуванням:
  - зсуву суботи/неділі на понеділок
  - 29 лютого завжди нормалізується до 1 березня

## Пов'язані Issues

Closes #6

## Тип змін

- [x] Нова функціональність (feature)
- [ ] Виправлення помилки (bugfix)
- [ ] Рефакторинг
- [ ] Документація
- [ ] Налаштування CI/інфраструктура

## Чекліст

- [x] Код відповідає стилю проєкту (ruff check, ruff format)
- [x] Типи перевірені (mypy)
- [x] Тести для моєї задачі зелені
- [x] Я не змінював тестові файли
- [x] Я не змінював сигнатури методів
- [x] PR створений у гілку `develop`
- [x] PR створений як Draft та переведений у Ready for review після проходження тестів
- [x] Задача на [Project Board](https://github.com/users/yevhen-kalyna/projects/5) переведена в **In Review**

## Додаткові коментарі

`datetime` імпортовано як модуль-рівнева змінна (`datetime = __import__("datetime").datetime`) для підтримки `monkeypatch` у тесті `test_upcoming_birthdays_feb29_in_non_leap_year`.
Усі 22 тести в `test_address_book.py` зелені.

