### PR TITLE
feat(note-handlers): implement all 8 note command handlers

### DIFF
--- a/personal_assistant/handlers/note_handlers.py
+++ b/personal_assistant/handlers/note_handlers.py
@@ -1,50 +1,102 @@
+from personal_assistant.models.note import Note
 from personal_assistant.models.note_book import NoteBook
 from personal_assistant.utils import input_error
+
+_NOTE_NOT_FOUND = "Note not found."
+
+
+def _format_note(note: Note) -> str:
+    return f"ID: {note.id}\n{note}"
 
 
 @input_error
 def add_note_handler(args: list[str], notebook: NoteBook) -> str:
     """Додає нову нотатку."""
-    raise NotImplementedError
+    if not args:
+        raise IndexError
+    title = args[0]
+    body = input("Enter note body: ")
+    note = Note(title, body)
+    notebook.add_note(note)
+    return "Note added."
 
 
 @input_error
 def find_note_handler(args: list[str], notebook: NoteBook) -> str:
     """Пошук нотаток за текстом."""
-    raise NotImplementedError
+    if not args:
+        raise IndexError
+    query = args[0]
+    results = notebook.find_by_text(query)
+    if not results:
+        return "No notes found."
+    return "\n".join(_format_note(note) for note in results)
 
 
 @input_error
 def edit_note_handler(args: list[str], notebook: NoteBook) -> str:
     """Редагує нотатку."""
-    raise NotImplementedError
+    if not args:
+        raise IndexError
+    note_id = args[0]
+    note = notebook.find(note_id)
+    if note is None:
+        return _NOTE_NOT_FOUND
+    new_body = input("Enter new note body: ")
+    notebook.edit_note(note_id, new_body)
+    return "Note updated."
 
 
 @input_error
 def delete_note_handler(args: list[str], notebook: NoteBook) -> str:
     """Видаляє нотатку."""
-    raise NotImplementedError
+    if not args:
+        raise IndexError
+    note_id = args[0]
+    note = notebook.find(note_id)
+    if note is None:
+        return _NOTE_NOT_FOUND
+    notebook.delete(note_id)
+    return "Note deleted."
 
 
 @input_error
 def all_notes_handler(notebook: NoteBook) -> str:
     """Показує всі нотатки."""
-    raise NotImplementedError
+    if not notebook.data:
+        return "No notes saved."
+    return "\n".join(_format_note(note) for note in notebook.data.values())
 
 
 @input_error
 def add_tag_handler(args: list[str], notebook: NoteBook) -> str:
     """Додає тег до нотатки."""
-    raise NotImplementedError
+    if len(args) < 2:
+        raise IndexError
+    note_id, tag = args[0], args[1]
+    note = notebook.find(note_id)
+    if note is None:
+        return _NOTE_NOT_FOUND
+    note.add_tag(tag)
+    return "Tag added."
 
 
 @input_error
 def find_by_tag_handler(args: list[str], notebook: NoteBook) -> str:
     """Пошук нотаток за тегом."""
-    raise NotImplementedError
+    if not args:
+        raise IndexError
+    tag = args[0]
+    results = notebook.find_by_tag(tag)
+    if not results:
+        return "No notes found."
+    return "\n".join(_format_note(note) for note in results)
 
 
 @input_error
 def sort_notes_by_tag_handler(notebook: NoteBook) -> str:
     """Сортує нотатки за тегами."""
-    raise NotImplementedError
+    if not notebook.data:
+        return "No notes saved."
+    sorted_notes = notebook.sort_by_tags()
+    return "\n".join(_format_note(note) for note in sorted_notes)


### PR DESCRIPTION
## Опис змін

Реалізовано всі 8 обробників команд для роботи з нотатками у файлі
`personal_assistant/handlers/note_handlers.py`.

Замінено заглушки `raise NotImplementedError` на повну реалізацію:

| Обробник | Що робить |
|---|---|
| `add_note_handler` | Додає нотатку (title з args, body через `input()`) |
| `find_note_handler` | Шукає нотатки за текстом (часткове співпадіння) |
| `edit_note_handler` | Редагує body нотатки за ID (новий body через `input()`) |
| `delete_note_handler` | Видаляє нотатку за ID |
| `all_notes_handler` | Виводить всі нотатки |
| `add_tag_handler` | Додає тег до нотатки за ID |
| `find_by_tag_handler` | Шукає нотатки за тегом |
| `sort_notes_by_tag_handler` | Повертає нотатки посортовані за тегами |

## Пов'язані Issues

<!-- Вкажіть номер Issue для цього завдання -->
Closes #11

## Тип змін

- [x] Нова функціональність (feature)
- [ ] Виправлення помилки (bugfix)
- [ ] Рефакторинг
- [ ] Документація
- [ ] Налаштування CI/інфраструктура

## Чекліст

- [x] Код відповідає стилю проєкту (ruff check, ruff format)
- [x] Типи перевірені (mypy — no issues found)
- [x] Тести для моєї задачі зелені (39/39 passed у test_handlers.py)
- [x] Я не змінював тестові файли
- [x] Я не змінював сигнатури методів
- [x] PR створений у гілку `develop`
- [x] PR створений як Draft та переведений у Ready for review після проходження тестів
- [x] Задача на [Project Board](https://github.com/users/yevhen-kalyna/projects/5) переведена в **In Review**

## Додаткові коментарі